### PR TITLE
feat: update make targets and corresponding docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ build: clean ## build contracts
 	forge build
 
 .PHONY: test
-test: build ## run tests
+test: ## run tests
 	forge test

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,29 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: test
-test: build ## run tests
-	forge test --match-contract RiftTokenTest
-	forge test --match-contract CoreTest
-	forge test --match-contract UniswapVaultTest
-	forge test --match-contract MasterChefVaultTest
-	forge test --match-contract MasterChefV2VaultTest
-	forge test --match-contract NativeVaultTest
+check-%:
+	@ if [[ -z "${${*}}" ]]; then \
+        echo "Environment variable $* not set"; \
+        exit 1; \
+    fi
+
+.PHONY: bootstrap
+bootstrap: check-ALCHEMY_API_KEY install ## bootstrap project
+	@sed 's/{YOUR_API_KEY}/${ALCHEMY_API_KEY}/g' foundry.toml > foundry.temp
+	@mv foundry.temp foundry.toml
+
+.PHONY: install
+install: ## install dependencies
+	yarn && forge update
+
+.PHONY: clean
+clean: ## clean build artifacts
+	forge clean
 
 .PHONY: build
-build: ## clean and build contracts
-	forge clean && forge build
+build: clean ## build contracts
+	forge build
+
+.PHONY: test
+test: build ## run tests
+	forge test

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ See the [Rift Documentation](https://docs.rift.finance/protocol-overview/smart-c
 ## Getting Started
 
 1. Install [foundry](https://github.com/gakonst/foundry#installation)
-2. Install dependencies with `yarn` and `forge update`
+2. Bootstrap with `ALCHEMY_API_KEY=<your api key> make bootstrap`
 3. Compile contracts with `make build`
-4. Add your RPC URL API key to `foundry.toml`
-5. Run tests with `make test`
+4. Run tests with `make test`
 
 ## Contract Structure
 


### PR DESCRIPTION
- use `forge test` to run all tests concurrently, instead of testing
  each contract sequentially. this is possible thanks to a recent forge
  update
- and install and bootstrap targets for because "onboarding as code" >
  "onboarding as docs"